### PR TITLE
CarouselCaption: Add slot with defaults

### DIFF
--- a/src/components/CarouselCaption.vue
+++ b/src/components/CarouselCaption.vue
@@ -1,25 +1,27 @@
 <template>
   <div :is="tag" class="carousel-caption">
-    <h3 class="h3-responsive">{{ title }}</h3>
-    <p>{{ text }}</p>
+    <slot>
+      <h3 class="h3-responsive">{{ title }}</h3>
+      <p>{{ text }}</p>
+    </slot>
   </div>
 </template>
 
 <script>
-export default {
-  props: {
-    tag: {
-      type: String,
-      default: "div"
+  export default {
+    props: {
+      tag: {
+        type: String,
+        default: "div"
+      },
+      title: {
+        type: String
+      },
+      text: {
+        type: String
+      }
     },
-    title: {
-      type: String
-    },
-    text: {
-      type: String
-    }
-  },
-};
+  };
 </script>
 
 <style scoped>


### PR DESCRIPTION
This PR adds a `<slot>` to the captions with default content.

Now users can do things like:
```html
<carousel-caption title="First Slide" text="Secondary text"></carousel-caption>
```

OR

```html
<carousel-caption>
   <h2>First Slide</h2>
   <p>Secondary text</p>
   <btn>Button</btn>
</carousel-caption>
```