### PR TITLE
navbar-item not work in history mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,12 @@
 <template>
   <div id="app" class="flyout">
-    <navbar position="top" class="default-color navbar-dark" name="MDB Vue" href="#/" scrolling>
+    <navbar position="top" class="default-color navbar-dark" name="MDB Vue" to="/" scrolling>
       <navbar-collapse>
         <navbar-nav right>
-          <navbar-item href="#/" waves-fixed>Home</navbar-item>
-          <navbar-item href="#/css" waves-fixed>CSS</navbar-item>
-          <navbar-item href="#/components" waves-fixed>Components</navbar-item>
-          <navbar-item href="#/advanced" waves-fixed>Advanced</navbar-item>
+          <navbar-item to="/" waves-fixed>Home</navbar-item>
+          <navbar-item to="/css" waves-fixed>CSS</navbar-item>
+          <navbar-item to="/components" waves-fixed>Components</navbar-item>
+          <navbar-item to="/advanced" waves-fixed>Advanced</navbar-item>
         </navbar-nav>
       </navbar-collapse>
     </navbar>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -1,8 +1,8 @@
 <template>
   <nav :class="className" :is="tag">
-    <a :href="href" class="navbar-brand">{{name}}
+    <router-link tag="a" :to="to" class="navbar-brand" exact>{{name}}
       <img v-if="src" :src="src" :alt="alt"/>
-    </a>
+    </router-link>
     <button class="navbar-toggler" type="button" data-toggle="collapse" :data-target="target" aria-controls="navbarSupportedContent"
         aria-expanded="false" aria-label="Toggle navigation" v-on:click="toggle">
       <span class="navbar-toggler-icon"></span>
@@ -28,7 +28,7 @@ export default {
     position: {
       type: String
     },
-    href: {
+    to: {
       type: String,
     },
     src: {

--- a/src/components/NavbarItem.vue
+++ b/src/components/NavbarItem.vue
@@ -1,6 +1,6 @@
 <template>
   <li :is="tag" :class="[className, {'ripple-parent': waves}]" @click="wave">
-    <a :href="href" class="nav-link"><slot></slot></a>
+    <router-link :to="to" class="nav-link"><slot></slot></router-link>
   </li>
 </template>
 
@@ -18,9 +18,9 @@ export default {
       type: Boolean,
       default: false
     },
-    href: {
+    to: {
       type: String,
-      default: '#'
+      default: '/'
     },
     waves: {
       type: Boolean,


### PR DESCRIPTION
For navbar-item to work in history mode, it should be surrounded by original router component - router-link. It will correctly deal with links.