### PR TITLE
Fixed e.path error

### DIFF
--- a/src/components/MdInput.vue
+++ b/src/components/MdInput.vue
@@ -119,7 +119,7 @@ export default {
       }
     },
     change(e) {
-      this.innerValue = e.path[0].value;
+      this.innerValue = this.$refs.input.value;
     }
   },
   mixins: [waves]


### PR DESCRIPTION
event.path is only supported by chrome browser and causes errors in other browsers.