### PR TITLE
Give Column the plain col class by default

### DIFF
--- a/src/components/Col.vue
+++ b/src/components/Col.vue
@@ -45,6 +45,7 @@ export default {
   data() {
     return {
       className: classNames(
+        !this.col && !this.sm && !this.md && !this.lg && !this.xl ? 'col' : '',
         this.col ? 'col-' + this.col : '',
         this.sm ? 'col-sm-' + this.sm : '',
         this.md ? 'col-md-' + this.md : '',


### PR DESCRIPTION
Give Column the plain col class by default when no parameters are specified. This fixes the issue of plain columns becoming plain divs, and not work with bootstrap (like not auto-sizing, for example).