### PR TITLE
fix CollapsePages ToggleBoth behavior

### DIFF
--- a/src/docs/CollapsePage.vue
+++ b/src/docs/CollapsePage.vue
@@ -13,7 +13,7 @@
     <h3 class="mt-5">Multiple targets</h3>
     <mdb-btn color="primary" @click.native.prevent="collapse2 === true ? collapse2 = false : collapse2 = true">Toggle first element</mdb-btn>
     <mdb-btn color="primary" @click.native.prevent="collapse3 === true ? collapse3 = false : collapse3 = true">Toggle second element</mdb-btn>
-    <mdb-btn color="primary" @click.native.prevent="[collapse2 === true ? collapse2 = false : collapse2 = true] && [collapse3 === true ? collapse3 = false : collapse3 = true]">Toggle both elements</mdb-btn>
+    <mdb-btn color="primary" @click.native.prevent="[collapse2 === true ? collapse2 = false : collapse2 = true] [collapse3 === true ? collapse3 = false : collapse3 = true]">Toggle both elements</mdb-btn>
     <mdb-row>
       <mdb-col sm="6">
         <transition @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave">


### PR DESCRIPTION
I am always happy to use it.

I made a pull request, thinking that the 'Toggle both elements' button in the advanced category Collapse had an unintended behavior.

Pressing the 'Toggle both elements' button will move the element by one.

I thought that the two elements moved but it was not correct.

## Before
![before](https://user-images.githubusercontent.com/20323093/55507242-2f486b80-5692-11e9-90f6-d59631dd52af.gif)

## After
![after](https://user-images.githubusercontent.com/20323093/55507255-34a5b600-5692-11e9-8241-dbb75ab0c1be.gif)

