### PR TITLE
Changing CSS selector to "Child combinator"

### DIFF
--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -289,7 +289,7 @@
     visibility: hidden;
   }
 
-  .show .popover {
+  .show > .popover {
     opacity: 1;
     visibility: visible;
   }


### PR DESCRIPTION
In order to enable nesting popovers inside each other (or placing popovers inside bootstrap collapse for example) without showing the nested popover in advance, I changed the css selector to the [Child Combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator) '>' to achieve this.

Here's an example without the selector: https://pasteboard.co/IaqW0nh.gif
Here's an example with the selector: https://pasteboard.co/IaqWlBT.gif