### PR TITLE
Little english typo

### DIFF
--- a/src/components/Tables/Datatable.vue
+++ b/src/components/Tables/Datatable.vue
@@ -285,7 +285,7 @@ const Datatable = {
     },
     previous: {
       type: String,
-      default: 'Previos'
+      default: 'Previous'
     },
     arrows: {
       type: Boolean,


### PR DESCRIPTION
Just added a "u" in "Previos". Not really a code change, but helpful to avoid remarks like "dude,  you skipped a "u""